### PR TITLE
フラッシュメーセージの追加

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -11,7 +11,7 @@
     <div class='collapse navbar-collapse' id='navbarSupportedContent'>
       <ul class='navbar-nav ms-auto main-nav align-items-center'>
         <li class="nav-item">
-          <%= link_to 'ログイン', login_path ,class: 'nav-link' %>
+          <%= link_to t('header.login'), login_path ,class: 'nav-link' %>
         </li>
       </ul>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -26,7 +26,7 @@
 
         <li class='nav-item'>
           <%= link_to('#', class: 'nav-link') do %>
-            ブックマーク一覧
+            ブックマーク
           <% end %>
         </li>
 
@@ -40,7 +40,7 @@
             <%= link_to('#', class: 'dropdown-item') do %>
               プロフィール
             <% end %>
-            <%= link_to 'ログアウト', logout_path, class: 'dropdown-item', data: { turbo_method: :delete } %>
+            <%= link_to t('header.logout'), logout_path, class: 'dropdown-item', data: { turbo_method: :delete } %>
           </div>
         </li>
       </ul>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -16,7 +16,7 @@ ja:
     create:
       login_success: ログインしました
       login_failure: ログインに失敗しました
-      logout_success: ログアウトしました
+    logout_success: ログアウトしました
   users:
     new:
       title: ユーザー登録


### PR DESCRIPTION
ログイン時、登録時に下記のフラっすメッセージが出るようにしました。

ログイン成功時・・・・・「ログインしました」
ログイン失敗時・・・・・「ログインに失敗しました」
ログアウト時・・・・・・「ログアウトしました」
ユーザー登録時・・・・・「ユーザー登録が完了しました」
ユーザー登録失敗時・・・「ユーザー登録に失敗しました」