### PR TITLE
フォーム入力時エラー情報を個別表示

### DIFF
--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -3,24 +3,25 @@
     <div class="col-lg-8 offset-lg-2">
       <h1>期限チェックリスト作成</h1>
       <!-- ここからform_withを使う形に修正してください -->
-      <%= form_with(model: @board, local: true, class: "new_board") do |form| %>
+      <%= form_with(model: @board, local: true, class: "new_board") do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
         <div class="mb-3">
-          <%= form.label :store_name, "店名" %>
-          <%= form.text_field :store_name, id: "board_store_name", class: "form-control" %>
+          <%= f.label :store_name, "店名" %>
+          <%= f.text_field :store_name, id: "boards.store_name", class: "form-control" %>
         </div>
         <div class="mb-3">
-          <%= form.label :product_name, "商品名" %>
-          <%= form.text_field :product_name, id: "board_product_name", class: "form-control" %>
+          <%= f.label :product_name, "商品名" %>
+          <%= f.text_field :product_name, id: "board_product_name", class: "form-control" %>
         </div>
         <div class="mb-3">
-          <%= form.label :jan_code, "JANコード" %>
-          <%= form.text_field :jan_code, id: "board_jan_code", class: "form-control" %>
+          <%= f.label :jan_code, "JANコード" %>
+          <%= f.text_field :jan_code, id: "board_jan_code", class: "form-control" %>
         </div>
         <div class="mb-3">
-          <%= form.label :expiration_date, "期限日" %>
-          <%= form.text_field :expiration_date, id: "board_expiration_date", class: "form-control" %>
+          <%= f.label :expiration_date, "期限日" %>
+          <%= f.text_field :expiration_date, id: "board_expiration_date", class: "form-control" %>
         </div>
-        <%= form.submit "登録", class: "btn btn-primary", data: { disable_with: "登録中..." } %>
+        <%= f.submit "登録", class: "btn btn-primary", data: { disable_with: "登録中..." } %>
       <% end %>
       <!-- ここまでform_withを使う形に修正してください -->
     </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_explanation" class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,6 +4,7 @@
       <h1><%= t('users.new.title')%></h1>
       
       <%= form_with model: @user, local: true do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
         <div class="mb-3">
           <%= f.label :last_name, class: "form-label" %>
           <%= f.text_field :last_name, class: "form-control", id: "user_last_name" %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,3 +9,8 @@ ja:
         first_name: 名
         password: パスワード
         password_confirmation: パスワード確認
+      board:
+        store_name: 店名
+        product_name: 商品名
+        jan_code: JANコード
+        expiration_date: 期限日


### PR DESCRIPTION
## **課題概要**

- createアクション時にエラーが出た際に、どこでどのようなエラーが出たのかを１つずつ表示させるようにしてください

## **確認ポイント**

- 掲示板情報の入力フォームで全項目が未入力で作成ボタンを押した場合、「店名を入力してください」「商品名を入力してください」「JANコードを入力してください」「店名を入力してください」「期限日を入力してください」というエラーメッセージが表示されること
- 掲示板情報の入力フォームで入力文字を超過して作成ボタンを押した場合、「店名は255文字以内で入力してください」「商品名は255文字以内で入力してください」「JANコードは13文字以内で入力してください」というエラーメッセージが表示されること
- ユーザー情報の入力フォームで全項目が未入力で作成ボタンを押した場合、「姓を入力してください」「名を入力してください」「メールアドレスを入力してください」「パスワードを入力してください」というエラーメッセージが表示されること