### PR TITLE
掲示板詳細画面の追加/コメント機能の実装

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -20,6 +20,13 @@ class BoardsController < ApplicationController
     end
   end
 
+  def show
+    @board = Board.find(params[:id])
+    @comment = Comment.new
+    @store_name = @board.store_name
+    @comments = @board.comments.includes(:user).order(created_at: :desc)
+  end
+
   private
 
   def board_params

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,5 +1,5 @@
 class BoardsController < ApplicationController
-  before_action :require_login, only: %i[index new create]
+  before_action :require_login, only: %i[index new create show]
 
   def index
     @boards = Board.includes(:user).order(created_at: :desc)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,6 +7,7 @@ class CommentsController < ApplicationController
     else
       flash[:danger] = t('comments.comment_danger')
       @board = Board.find(params[:board_id])
+      @comments = @board.comments.includes(:user).order(created_at: :desc) # ここで@commentsをセット
       render 'boards/show', status: :unprocessable_entity
     end
   end
@@ -14,6 +15,6 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:body).merge(user_id: current_user.id)
+    params.require(:comment).permit(:body, :board_id).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,19 @@
+class CommentsController < ApplicationController
+  def create
+    @comment = current_user.comments.build(comment_params)
+    if @comment.save
+      flash[:success] = t('comments.comment_success')
+      redirect_to board_path(@comment.board)
+    else
+      flash[:danger] = t('comments.comment_danger')
+      @board = Board.find(params[:board_id])
+      render 'boards/show', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body).merge(user_id: current_user.id)
+  end
+end

--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -1,0 +1,13 @@
+class CommentDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -4,4 +4,6 @@ class Board < ApplicationRecord
   validates :product_name, presence: true, length: { maximum: 255 }
   validates :jan_code, presence: true, length: { maximum: 13 }
   validates :expiration_date, presence: true
+
+  has_many :comments, dependent: :destroy
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :board
+
+  validates :body, presence: true, length: { maximum: 65535 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,6 @@ class User < ApplicationRecord
 
   has_many :boards
 
+  has_many :comments, dependent: :destroy
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,8 @@ class User < ApplicationRecord
 
   has_many :comments, dependent: :destroy
 
+  def own?(comment)
+    self.id == comment.user_id
+  end
+
 end

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -4,7 +4,7 @@
       <div class="card-body">
         <div class="d-flex">
           <h4 class="card-title">
-            <%= link_to board.store_name, '#' %>
+            <%= link_to board.store_name, board_path(board) %>
           </h4>
           <div class='ms-auto'>
             <%= link_to '#', id: 'button-edit-#{board.id}' do %>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -6,7 +6,7 @@
         <div class="card-body">
           <div class="row">
             <div class="col-md-9">
-              <h3 style="display: inline;"><%= @store.name %></h3>
+              <h3 style="display: inline;"><%= @store_name %></h3>
               <ul class="list-inline">
                 <li class="list-inline-item"><%= "by #{@board.user.decorate.full_name}" %></li>
                 <li class="list-inline-item"><%= l @board.created_at, format: :long %></li>
@@ -22,9 +22,9 @@
             </div>
           </div>
           <p>
-            商品名: <%= @product.name %><br>
-            JANコード: <%= @product.jan_code %><br>
-            期限日: <%= l @product.expiration_date, format: :long %>
+            商品名: <%= @board.product_name %><br>
+            JANコード: <%= @board.jan_code %><br>
+            期限日: <%= l @board.expiration_date, format: :long %>
           </p>
         </div>
       </article>

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -1,0 +1,45 @@
+<div class="container pt-5">
+  <div class="row mb-3">
+    <div class="col-lg-8 offset-lg-2">
+      <h1><%= t('.title') %></h1>
+      <article class="card">
+        <div class="card-body">
+          <div class="row">
+            <div class="col-md-9">
+              <h3 style="display: inline;"><%= @store.name %></h3>
+              <ul class="list-inline">
+                <li class="list-inline-item"><%= "by #{@board.user.decorate.full_name}" %></li>
+                <li class="list-inline-item"><%= l @board.created_at, format: :long %></li>
+              </ul>
+              <div class='d-flex justify-content-end'>
+                <%= link_to "#", id: "button-edit-#{@board.id}" do %>
+                  <i class='bi bi-pencil-fill'></i>
+                <% end %>
+                <%= link_to "#", id: "button-delete-#{@board.id}", class: "ms-2" do %>
+                  <i class="bi bi-trash-fill"></i>
+                <% end %>
+              </div>
+            </div>
+          </div>
+          <p>
+            商品名: <%= @product.name %><br>
+            JANコード: <%= @product.jan_code %><br>
+            期限日: <%= l @product.expiration_date, format: :long %>
+          </p>
+        </div>
+      </article>
+    </div>
+  </div>
+  <!-- コメントフォーム -->
+  <%= render 'comments/form', comment: @comment, board: @board %> 
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <table class="table">
+        <tbody id="table-comment">
+          <!-- コメントエリア -->
+          <%= render @comments %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,25 @@
+<tr id="comment-<%= comment.id %>">
+  <td style="width: 60px">
+    <%= image_tag "sample", width: "50", height: "50", class: "rounded-circle" %>
+  </td>
+  <td>
+    <h3 class="small"><%= comment.user.decorate.full_name %></h3>
+    <p><%= simple_format(comment.body) %></p>
+  </td>
+  <% if current_user.own?(comment) %>
+    <td class="action">
+      <ul class="list-inline justify-content-center" style="float: right;">
+        <li class="list-inline-item">
+          <%= link_to "#", class: "edit-comment-link" do %>
+            <i class="bi bi-pencil-fill"></i>
+          <% end %>
+        </li>
+        <li class="list-inline-item">
+          <%= link_to "#", class: "delete-comment-link" do %>
+            <i class="bi bi-trash-fill"></i>
+          <% end %>
+        </li>
+      </ul>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,9 @@
+<div class="row mb-3" id="comment-form">
+  <div class="col-lg-8 offset-lg-2">
+    <%= form_with model: comment, url: board_comments_path(board) do |f| %>
+      <%= f.label :body %>
+      <%= f.text_area :body, class: "form-control mb-3", row: "4", placeholder: Comment.human_attribute_name(:body) %>
+      <%= f.submit t('defaults.post'), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,7 @@
 <div class="row mb-3" id="comment-form">
   <div class="col-lg-8 offset-lg-2">
     <%= form_with model: comment, url: board_comments_path(board) do |f| %>
+      <%= f.hidden_field :board_id, value: board.id %>
       <%= f.label :body %>
       <%= f.text_area :body, class: "form-control mb-3", row: "4", placeholder: Comment.human_attribute_name(:body) %>
       <%= f.submit t('defaults.post'), class: "btn btn-primary" %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,6 +2,8 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      board: 掲示板
+      comment: コメント
     attributes:
       user:
         email: メールアドレス
@@ -14,3 +16,5 @@ ja:
         product_name: 商品名
         jan_code: JANコード
         expiration_date: 期限日
+      comment:
+        body: コメント

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -41,5 +41,14 @@ ja:
     boards:
       success: 期限チェックリストを作成できました
       danger: 期限チェックリストを作成できませんでした
-    
-
+  defaults:
+    post: 投稿
+  boards:
+    new:
+      title: 掲示板作成
+    show:
+      title: 掲示板詳細
+  comments:
+    comment_success: コメントを作成しました
+    comment_dander: コメントを作成出来ませんでした
+  

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -50,5 +50,5 @@ ja:
       title: 掲示板詳細
   comments:
     comment_success: コメントを作成しました
-    comment_dander: コメントを作成出来ませんでした
+    comment_danger: コメントを作成出来ませんでした
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   get "up" => "rails/health#show", as: :rails_health_check
 
-  resources :boards, only: [:new, :create, :index]
+  resources :boards, only: [:new, :create, :index, :show]
 
   # コメント処理のルート設定
   resources :boards do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,9 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   resources :boards, only: [:new, :create, :index]
+
+  # コメント処理のルート設定
+  resources :boards do
+    resources :comments, shallow: true, only: %i[create]
+  end
 end

--- a/db/migrate/20240524041139_create_comments.rb
+++ b/db/migrate/20240524041139_create_comments.rb
@@ -1,0 +1,13 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.integer :user_id, null: false
+      t.integer :board_id, null: false
+      t.text :body, null: false, limit: 65535
+
+      t.timestamps
+    end
+    add_foreign_key :comments, :users, on_delete: :cascade
+    add_foreign_key :comments, :boards, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_21_131141) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_24_041139) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_21_131141) do
     t.index ["user_id"], name: "index_boards_on_user_id"
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "board_id", null: false
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
@@ -37,4 +45,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_21_131141) do
   end
 
   add_foreign_key "boards", "users"
+  add_foreign_key "comments", "boards", on_delete: :cascade
+  add_foreign_key "comments", "users", on_delete: :cascade
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/comment_decorator_test.rb
+++ b/test/decorators/comment_decorator_test.rb
@@ -1,0 +1,4 @@
+require 'test_helper'
+
+class CommentDecoratorTest < Draper::TestCase
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  board_id: 1
+  body: MyText
+
+two:
+  user_id: 1
+  board_id: 1
+  body: MyText

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## **課題概要**

- 掲示板詳細画面を作成してください
- 作成した詳細ページでコメントが書き込めるようにしてください。
- 掲示板一覧画面から該当掲示板のタイトルを押すと、掲示板詳細画面に遷移するようにしてください。

## **確認ポイント**

- コメント用のテーブルとモデルを作成していること
- コメントのモデル名がCommentになっていること
- コメントのカラム名とカラムの型が以下ようになっており、指定されているバリデーションが設定されていること
    - ユーザーID: user_id(integer)
    - 掲示板ID: board_id(integer)
    - コメント: body(text), 未入力を許可せず、最大文字数65535文字の数バリデーションを設定してください
- DB上でコメントと掲示板・ユーザーのデータが紐付いている状態になっていること
- コメントと掲示板・ユーザーの各モデルに適切なアソシエーションが設定してあること
- コメントを投稿したユーザーが削除されると、ユーザーが投稿したコメントも削除されること
- コメントが投稿された掲示板が削除されると、掲示板に投稿されたコメントも削除されること
- 掲示板の詳細画面で掲示板の店名・商品名・JANコード・期限日・投稿者フルネーム・投稿日時が動的に表示されるようになっていること
- 掲示板詳細画面でコメントを動的に表示するようになっていること
- コメントにはコメントしたユーザーのアバター・フルネームが表示されていること
- 掲示板に紐づくコメントが複数存在する場合、最新のコメントが最上部に表示されること
- ユーザー自身が作成したコメントにのみ編集リンクと削除リンクがログインしている表示されていること
- コメント作成時に「コメントを作成しました」というフラッシュメッセージが表示されること
- コメント作成失敗時に「コメントを作成出来ませんでした」というフラッシュメッセージが表示されること
- コメントの作成が成功した際には掲示板の詳細画面にリダイレクトすること
- コメントの作成が失敗した際には掲示板の詳細画面にリダイレクトすること